### PR TITLE
Refactor vaultd secret loading

### DIFF
--- a/vaultd/main.go
+++ b/vaultd/main.go
@@ -1,25 +1,57 @@
 package main
 
 import (
-go.mod "fmt"
-go.mod "log"
-go.mod "net/http"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
 )
 
+func handlePull(w http.ResponseWriter, r *http.Request) {
+	key := r.URL.Query().Get("key")
+	if key == "" {
+		http.Error(w, "missing key", http.StatusBadRequest)
+		return
+	}
+
+	val, err := GetEnvSecret(key)
+	if err != nil {
+		if errors.Is(err, ErrForbidden) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprint(w, val)
+}
+
+func handleInject(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "💾 Secret stored")
+}
+
+func handleHandoff(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "🤝 Secret handed off")
+}
+
+func handleHealthz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`))
+}
+
 func main() {
-go.mod http.HandleFunc("/pull", func(w http.ResponseWriter, r *http.Request) {
-go.mod go.mod key := r.URL.Query().Get("key")
-go.mod go.mod fmt.Fprintf(w, "🔐 Fetched secret for key: %s", key)
-go.mod })
+	loadOnce.Do(loadEnv)
+	if loadErr != nil {
+		log.Printf("Warning: %v", loadErr)
+	}
 
-go.mod http.HandleFunc("/inject", func(w http.ResponseWriter, r *http.Request) {
-go.mod go.mod fmt.Fprintln(w, "💾 Secret stored")
-go.mod })
+	http.HandleFunc("/pull", handlePull)
+	http.HandleFunc("/inject", handleInject)
+	http.HandleFunc("/handoff", handleHandoff)
+	http.HandleFunc("/healthz", handleHealthz)
 
-go.mod http.HandleFunc("/handoff", func(w http.ResponseWriter, r *http.Request) {
-go.mod go.mod fmt.Fprintln(w, "🤝 Secret handed off")
-go.mod })
-
-go.mod log.Println("Vaultd is running on :8080")
-go.mod log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Println("Vaultd is running on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/vaultd/secrets.go
+++ b/vaultd/secrets.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/joho/godotenv"
+)
+
+var (
+	loadOnce sync.Once
+	loadErr  error
+	allowSet map[string]struct{}
+)
+
+// ErrForbidden is returned when a requested secret is not in the allow list.
+var ErrForbidden = errors.New("secret not allowed")
+
+func loadEnv() {
+	if err := godotenv.Load(); err != nil && !os.IsNotExist(err) {
+		loadErr = err
+		return
+	}
+	data, err := os.ReadFile(".env.allow")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		loadErr = err
+		return
+	}
+	allowSet = make(map[string]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		allowSet[line] = struct{}{}
+	}
+}
+
+// GetEnvSecret loads secrets from .env and returns the value for key.
+// If .env.allow exists, only keys listed within are returned.
+func GetEnvSecret(key string) (string, error) {
+	loadOnce.Do(loadEnv)
+	if loadErr != nil {
+		return "", loadErr
+	}
+	if allowSet != nil {
+		if _, ok := allowSet[key]; !ok {
+			return "", ErrForbidden
+		}
+	}
+	val := os.Getenv(key)
+	if val == "" {
+		return "", fmt.Errorf("secret %s not found", key)
+	}
+	return val, nil
+}


### PR DESCRIPTION
## Summary
- refactor `vaultd` server to use `GetEnvSecret`
- add optional `.env.allow` whitelist support
- preload environment with logging and add `/healthz` endpoint

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685bc7854eec83308fbb44fb66876db4