### PR TITLE
Add persistent injection endpoint in vaultd

### DIFF
--- a/vaultd/main.go
+++ b/vaultd/main.go
@@ -1,76 +1,108 @@
 package main
 
 import (
-"errors"
-"fmt"
-"log"
-"net/http"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
 )
 
 func handlePull(w http.ResponseWriter, r *http.Request) {
-key := r.URL.Query().Get("key")
-if key == "" {
-http.Error(w, "missing key", http.StatusBadRequest)
-return
+	key := r.URL.Query().Get("key")
+	if key == "" {
+		http.Error(w, "missing key", http.StatusBadRequest)
+		return
+	}
+
+	val, err := GetEnvSecret(key)
+	if err != nil {
+		if errors.Is(err, ErrForbidden) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprint(w, val)
 }
 
-val, err := GetEnvSecret(key)
-if err != nil {
-if errors.Is(err, ErrForbidden) {
-http.Error(w, "forbidden", http.StatusForbidden)
-return
-}
-http.Error(w, err.Error(), http.StatusInternalServerError)
-return
-}
-<<<<<<< ours
-
-fmt.Fprint(w, val)
-}
-
+// P2-I1 Inject endpoint persistent storage
 func handleInject(w http.ResponseWriter, r *http.Request) {
-fmt.Fprintln(w, "💾 Secret stored")
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var key, value string
+	if r.Header.Get("Content-Type") == "application/json" {
+		var body struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		key = body.Key
+		value = body.Value
+	} else {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		key = r.FormValue("key")
+		value = r.FormValue("value")
+	}
+
+	if key == "" {
+		http.Error(w, "missing key", http.StatusBadRequest)
+		return
+	}
+
+	if allowSet != nil {
+		if _, ok := allowSet[key]; !ok {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+	}
+
+	if err := SetEnvSecret(key, value); err != nil {
+		log.Printf("inject error: %v", err)
+		if errors.Is(err, ErrForbidden) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		http.Error(w, "failed to store secret", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	fmt.Fprint(w, "stored")
 }
 
 func handleHandoff(w http.ResponseWriter, r *http.Request) {
-fmt.Fprintln(w, "🤝 Secret handed off")
-}
-
-func main() {
-http.HandleFunc("/pull", handlePull)
-http.HandleFunc("/inject", handleInject)
-http.HandleFunc("/handoff", handleHandoff)
-=======
-
-fmt.Fprint(w, val)
-}
-
-func handleInject(w http.ResponseWriter, r *http.Request) {
-fmt.Fprintln(w, "💾 Secret stored")
-}
-
-func handleHandoff(w http.ResponseWriter, r *http.Request) {
-fmt.Fprintln(w, "🤝 Secret handed off")
+	fmt.Fprintln(w, "🤝 Secret handed off")
 }
 
 func handleHealthz(w http.ResponseWriter, r *http.Request) {
-w.Header().Set("Content-Type", "application/json")
-w.WriteHeader(http.StatusOK)
-w.Write([]byte(`{"status":"ok"}`))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`))
 }
 
 func main() {
-loadOnce.Do(loadEnv)
-if loadErr != nil {
-log.Printf("Warning: %v", loadErr)
-}
+	loadOnce.Do(loadEnv)
+	if loadErr != nil {
+		log.Printf("Warning: %v", loadErr)
+	}
 
-http.HandleFunc("/pull", handlePull)
-http.HandleFunc("/inject", handleInject)
-http.HandleFunc("/handoff", handleHandoff)
-http.HandleFunc("/healthz", handleHealthz)
->>>>>>> theirs
+	http.HandleFunc("/pull", handlePull)
+	http.HandleFunc("/inject", handleInject)
+	http.HandleFunc("/handoff", handleHandoff)
+	http.HandleFunc("/healthz", handleHealthz)
 
-log.Println("Vaultd is running on :8080")
-log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Println("Vaultd is running on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/vaultd/secrets.go
+++ b/vaultd/secrets.go
@@ -1,62 +1,110 @@
 package main
 
 import (
-"errors"
-"fmt"
-"os"
-"strings"
-"sync"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
 
-"github.com/joho/godotenv"
+	"github.com/joho/godotenv"
 )
 
 var (
-loadOnce sync.Once
-loadErr  error
-allowSet map[string]struct{}
+	loadOnce sync.Once
+	loadErr  error
+	allowSet map[string]struct{}
 )
 
 // ErrForbidden is returned when a requested secret is not in the allow list.
 var ErrForbidden = errors.New("secret not allowed")
 
 func loadEnv() {
-if err := godotenv.Load(); err != nil && !os.IsNotExist(err) {
-loadErr = err
-return
-}
-data, err := os.ReadFile(".env.allow")
-if err != nil {
-if os.IsNotExist(err) {
-return
-}
-loadErr = err
-return
-}
-allowSet = make(map[string]struct{})
-for _, line := range strings.Split(string(data), "\n") {
-line = strings.TrimSpace(line)
-if line == "" || strings.HasPrefix(line, "#") {
-continue
-}
-allowSet[line] = struct{}{}
-}
+	if err := godotenv.Load(); err != nil && !os.IsNotExist(err) {
+		loadErr = err
+		return
+	}
+
+	data, err := os.ReadFile(".env.allow")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		loadErr = err
+		return
+	}
+
+	allowSet = make(map[string]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		allowSet[line] = struct{}{}
+	}
 }
 
 // GetEnvSecret loads secrets from .env and returns the value for key.
 // If .env.allow exists, only keys listed within are returned.
 func GetEnvSecret(key string) (string, error) {
-loadOnce.Do(loadEnv)
-if loadErr != nil {
-return "", loadErr
+	loadOnce.Do(loadEnv)
+	if loadErr != nil {
+		return "", loadErr
+	}
+	if allowSet != nil {
+		if _, ok := allowSet[key]; !ok {
+			return "", ErrForbidden
+		}
+	}
+	val := os.Getenv(key)
+	if val == "" {
+		return "", fmt.Errorf("secret %s not found", key)
+	}
+	return val, nil
 }
-if allowSet != nil {
-if _, ok := allowSet[key]; !ok {
-return "", ErrForbidden
-}
-}
-val := os.Getenv(key)
-if val == "" {
-return "", fmt.Errorf("secret %s not found", key)
-}
-return val, nil
+
+// SetEnvSecret writes or updates the given key/value in .env on disk and the process environment.
+func SetEnvSecret(key, value string) error {
+	loadOnce.Do(loadEnv)
+	if loadErr != nil {
+		return loadErr
+	}
+	if allowSet != nil {
+		if _, ok := allowSet[key]; !ok {
+			return ErrForbidden
+		}
+	}
+
+	os.Setenv(key, value)
+
+	data, err := os.ReadFile(".env")
+	if err != nil && !os.IsNotExist(err) {
+		log.Printf("read .env error: %v", err)
+		return err
+	}
+
+	var lines []string
+	found := false
+	if err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if line == "" {
+				continue
+			}
+			if strings.HasPrefix(line, key+"=") {
+				line = fmt.Sprintf("%s=%s", key, value)
+				found = true
+			}
+			lines = append(lines, line)
+		}
+	}
+	if !found {
+		lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+	}
+	out := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(".env", []byte(out), 0600); err != nil {
+		log.Printf("write .env error: %v", err)
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- fix main.go merge markers and implement `handleInject` storing secrets
- add persistent secret storage functionality to secrets.go

## Testing
- `go build ./...` *(fails: github.com/joho/godotenv@v1.5.1: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685db92c74f88330a8d4dee21660c7f3