### PR TITLE
Add fallback logger config

### DIFF
--- a/.llmstate/notes.jsonl
+++ b/.llmstate/notes.jsonl
@@ -2,3 +2,4 @@
 {"timestamp": "2025-06-30T11:13:56Z", "tag": "P0003", "note": "infra: add base compose stack for traefik/weaviate/minio/vaultd"}
 {"timestamp": "2025-06-30T20:54:13Z", "tag": "P0004", "note": "refactor: safety/lint fixes for agent-health-check script"}
 {"timestamp": "2025-06-30T21:15:45Z", "tag": "P0004", "note": "refactor: hardening agent_health script"}
+{"timestamp": "2025-06-30T22:00:10Z", "tag": "P0005", "note": "feat: add fallback logger config" }

--- a/.llmstate/patch-pipeline.jsonl
+++ b/.llmstate/patch-pipeline.jsonl
@@ -7,3 +7,5 @@
 { "id": 4, "status": "committed", "timestamp": "2025-06-30T20:54:13Z", "commit_sha": "" }
 { "id": 4, "status": "started", "timestamp": "2025-06-30T21:15:35Z", "goal": "refactor: hardening agent_health script" }
 { "id": 4, "status": "committed", "timestamp": "2025-06-30T21:15:45Z", "commit_sha": "" }
+{ "id": 5, "status": "started", "timestamp": "2025-06-30T22:00:00Z", "goal": "py: add fallback logger config" }
+{ "id": 5, "status": "committed", "timestamp": "2025-06-30T22:00:10Z", "commit_sha": "4991c3d41e2e76fba80934093edbead77cf83e7f" }

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+# PATCH-P0005: default log level configuration
+import os
+
+# Environment variable LOG_LEVEL; defaults to DEBUG if not set
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'DEBUG')

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,8 @@
+# PATCH-P0005: simple project logger
+import logging
+
+from config import LOG_LEVEL
+
+level = getattr(logging, LOG_LEVEL.upper(), logging.DEBUG)
+logging.basicConfig(level=level)
+logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add config.py and logger.py
- record patch state updates

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ba1f6270c8330b15d9d975aa635ec