### PR TITLE
Fix Compose YAML syntax

### DIFF
--- a/.llmstate/notes.jsonl
+++ b/.llmstate/notes.jsonl
@@ -2,3 +2,4 @@
 {"timestamp": "2025-06-30T11:13:56Z", "tag": "P0003", "note": "infra: add base compose stack for traefik/weaviate/minio/vaultd"}
 {"timestamp": "2025-06-30T20:54:13Z", "tag": "P0004", "note": "refactor: safety/lint fixes for agent-health-check script"}
 {"timestamp": "2025-06-30T21:15:45Z", "tag": "P0004", "note": "refactor: hardening agent_health script"}
+{"timestamp": "2025-07-07T16:00:03Z", "tag": "P0005", "note": "fix traefik image version and remove obsolete compose version"}

--- a/.llmstate/patch-pipeline.jsonl
+++ b/.llmstate/patch-pipeline.jsonl
@@ -7,3 +7,5 @@
 { "id": 4, "status": "committed", "timestamp": "2025-06-30T20:54:13Z", "commit_sha": "" }
 { "id": 4, "status": "started", "timestamp": "2025-06-30T21:15:35Z", "goal": "refactor: hardening agent_health script" }
 { "id": 4, "status": "committed", "timestamp": "2025-06-30T21:15:45Z", "commit_sha": "" }
+{ "id": 5, "status": "started", "timestamp": "2025-07-07T16:00:03Z", "goal": "fix docker compose YAML error" }
+{ "id": 5, "status": "committed", "timestamp": "2025-07-07T16:00:03Z", "commit_sha": "" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,24 @@
- # Patch P0003: Docker Compose stack for traefik/weaviate/minio/vaultd
- version: '3.8'
+# PATCH-P0005: fix traefik image version and remove obsolete compose version
 
- services:
-   traefik:
-     image: traefik:v2.14
-     container_name: traefik
-     restart: unless-stopped
-     networks:
-       - web
-     ports:
-       - "80:80"
-       - "443:443"
-     volumes:
-       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
-       - ./traefik/dynamic.yml:/etc/traefik/dynamic/dynamic.yml:ro
-       - /var/run/docker.sock:/var/run/docker.sock:ro
-     environment:
-       - CF_API_TOKEN=${CLOUDFLARE_API_TOKEN}
-       - CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}
+services:
+  traefik:
+    image: traefik:v2.11
+    container_name: traefik
+    restart: unless-stopped
+    networks:
+      - web
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic/dynamic.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - CF_API_TOKEN=${CLOUDFLARE_API_TOKEN}
+      - CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}
 
-   weaviate:
+  weaviate:
      image: semitechnologies/weaviate:latest
      container_name: weaviate
      depends_on:
@@ -34,7 +33,7 @@
      volumes:
        - weaviate_data:/data
 
-   minio:
+  minio:
      image: minio/minio:latest
      container_name: minio
      depends_on:
@@ -49,7 +48,7 @@
        - minio_data:/data
      command: server /data
 
-   vaultd:
+  vaultd:
      build:
        context: .
        dockerfile: Dockerfile
@@ -60,10 +59,10 @@
      networks:
        - web
 
- networks:
-   web:
-     driver: bridge
+networks:
+  web:
+    driver: bridge
 
- volumes:
-   weaviate_data:
-   minio_data:
+volumes:
+  weaviate_data:
+  minio_data:


### PR DESCRIPTION
## Summary
- fix docker compose YAML formatting
- update traefik image to v2.11
- log patch pipeline changes

## Testing
- `./vault-agent/vault-agent --help >/dev/null`
- `curl -fsS http://localhost:8080/healthz` *(fails: Couldn't connect to server)*
- `curl -fsS https://traefik.pegasuswingman.com/dashboard/` *(fails: 503)*
- `curl -fsS -k https://vector.pegasuswingman.com/v1/.well-known/ready` *(fails: 503)*
- `curl -fsS https://storage.pegasuswingman.com/minio/health/live` *(fails: 503)*
- `python3 - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('services', list(yaml.safe_load(open('docker-compose.yml'))))
PY`


------
https://chatgpt.com/codex/tasks/task_e_686bedbc039c8330bcf99a45eb876262