### PR TITLE
Integrate OpenAI Agent and Codex CI workflow

### DIFF
--- a/.github/workflows/openai-codex-ci.yml
+++ b/.github/workflows/openai-codex-ci.yml
@@ -1,0 +1,28 @@
+# PATCH-P0009: Run OpenAI Agent with Codex context
+name: OpenAI Codex CI
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  codex-agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install openai
+      - name: Run agent bootstrap
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          bash scripts/agent-bootstrap.sh --task "ci"
+      - name: Health check
+        run: |
+          python scripts/agent_health.py
+          cat .llmstate/agent-health.jsonl || true

--- a/.llmstate/agent-health.jsonl
+++ b/.llmstate/agent-health.jsonl
@@ -1,0 +1,6 @@
+{"tag": "HEALTH-1", "timestamp": "2025-07-26T05:49:14.543091Z", "agent": "vaultd", "status": "fail", "output": "curl: (7) Failed to connect to localhost port 8080 after 0 ms: Couldn't connect to server"}
+{"tag": "HEALTH-1", "timestamp": "2025-07-26T05:49:14.554471Z", "agent": "vault-agent", "status": "error", "output": "Unsafe characters in command: ./vault-agent/vault-agent --help >/dev/null"}
+{"tag": "HEALTH-1", "timestamp": "2025-07-26T05:49:14.554598Z", "agent": "traefik", "status": "fail", "output": "curl: (22) The requested URL returned error: 503"}
+{"tag": "HEALTH-1", "timestamp": "2025-07-26T05:49:14.749122Z", "agent": "weaviate", "status": "fail", "output": "curl: (22) The requested URL returned error: 503"}
+{"tag": "HEALTH-1", "timestamp": "2025-07-26T05:49:14.893942Z", "agent": "minio", "status": "fail", "output": "curl: (22) The requested URL returned error: 503"}
+{"tag": "HEALTH-1", "timestamp": "2025-07-26T05:49:15.073329Z", "agent": null, "event": "completed"}

--- a/.llmstate/notes.jsonl
+++ b/.llmstate/notes.jsonl
@@ -9,3 +9,5 @@
 {"timestamp":"2025-07-08T05:22:32Z","tag":"P0007","note":"add minimal Dockerfile for vaultd"}
 {"timestamp":"2025-07-08T05:23:40Z","tag":"P0008","note":"fix Traefik dnsChallenge config"}
 {"timestamp":"2025-07-08T05:51:33Z","tag":"P0008","note":"traefik: fix cloudflare resolver config"}
+{"timestamp":"2025-07-26T05:48:55Z","tag":"P0009","note":"docs: start OpenAI Agent/Codex CI/CD integration"}
+{"timestamp":"2025-07-26T05:48:55Z","tag":"P0009","note":"docs + workflow for OpenAI Agent/Codex CI"}

--- a/.llmstate/patch-pipeline.jsonl
+++ b/.llmstate/patch-pipeline.jsonl
@@ -24,3 +24,5 @@
 {"id":8,"status":"started","timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","goal":"fix traefik cloudflare resolver"}
 {"id":8,"status":"started","timestamp":"2025-07-08T05:22:37Z","goal":"fix Traefik dnsChallenge config"}
 {"id":8,"status":"started","timestamp":"2025-07-08T05:51:29Z","goal":"fix traefik cloudflare resolver"}
+{"id":9,"status":"started","timestamp":"2025-07-26T05:48:55Z","goal":"docs: add OpenAI Agent + Codex CI/CD integration"}
+{"id":9,"status":"committed","timestamp":"2025-07-26T05:48:55Z","commit_sha":"4e8ec331f46760b5bb14384125d9771fcd31cca0"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ This project uses append-only, always-synced state docs. All agents (Codex, GPT,
 
 For more: see `.llmstate/patch-pipeline.jsonl`.
 
+Additional guidance for running OpenAI Agent and Codex together is in
+`docs/openai-agent-cicd.md`.
+
 ## Agent Registry
 
 | Agent      | Health Check Command |

--- a/docs/openai-agent-cicd.md
+++ b/docs/openai-agent-cicd.md
@@ -1,0 +1,27 @@
+# OpenAI Agent + Codex CI/CD Integration
+
+This guide describes how to run OpenAI Agent and OpenAI Codex together to manage Vaultborn's infrastructure.
+
+## Overview
+
+The workflow pairs the Codex code assistant with the Agent runtime so that code changes produced by Codex can be validated and deployed automatically.
+
+1. **Codex Planning** – Codex analyses `.llmstate/*.jsonl` and `AGENTS.md` to plan a patch.
+2. **Agent Execution** – The Agent runs tasks described by Codex and updates state logs.
+3. **CI Pipeline** – GitHub Actions executes the Agent inside a container to verify and deploy infrastructure.
+
+## Requirements
+
+- `OPENAI_API_KEY` available in repository secrets.
+- Docker and GitHub Actions runners.
+
+## Running Locally
+
+```bash
+# PATCH-P0009: example invocation
+scripts/agent-bootstrap.sh --task "deploy-stack"
+```
+
+## CI/CD Workflow
+
+The `openai-codex-ci.yml` workflow runs on every push and provides the Agent with context from `AGENTS.md` and `.llmstate`.


### PR DESCRIPTION
## Summary
- add docs for running OpenAI Agent with Codex
- add GitHub Actions workflow `openai-codex-ci.yml`
- update `AGENTS.md` with link to new doc
- record health check output
- log patch metadata for **P0009**

## Testing
- `python scripts/agent_health.py`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68846bfa2c3c833089dedd47db332154